### PR TITLE
Bug-deleteFromFeatureModelWithChildren-Brtszz-Deleting Entire Lines Instead of Individual Featurenames

### DIFF
--- a/src/main/java/se/isselab/HAnS/featureModel/psi/impl/FeatureModelPsiImplUtil.java
+++ b/src/main/java/se/isselab/HAnS/featureModel/psi/impl/FeatureModelPsiImplUtil.java
@@ -264,10 +264,6 @@ public class FeatureModelPsiImplUtil {
             };
             WriteCommandAction.runWriteCommandAction(feature.getProject(), r);
         }
-
-        //FeatureReferenceUtil.rename();
-        //FeatureReferenceUtil.reset();
-
         return newFeatureName;
     }
 

--- a/src/main/java/se/isselab/HAnS/featureModel/psi/impl/FeatureModelPsiImplUtil.java
+++ b/src/main/java/se/isselab/HAnS/featureModel/psi/impl/FeatureModelPsiImplUtil.java
@@ -286,17 +286,11 @@ public class FeatureModelPsiImplUtil {
 
     private static void deleteFromFeatureModelWithChildren(@NotNull PsiElement feature) {
         Document document = PsiDocumentManager.getInstance(feature.getProject()).getDocument(feature.getContainingFile());
-        int startOffset = feature.getTextOffset();
-        int endOffset = feature.getTextOffset() + feature.getNode().getTextLength();
-
         if (document != null) {
-            String documentText = document.getText();
-            String sub = documentText.substring(0, startOffset);
-            String remainder = documentText.substring(endOffset);
-            String newContent = sub.concat(remainder);
+            int lineStartOffset = document.getLineStartOffset(document.getLineNumber(feature.getTextOffset()));
+            int lineEndOffset = document.getLineEndOffset(document.getLineNumber(feature.getTextOffset())) + 1;
             Runnable r = () -> {
-                document.setReadOnly(false);
-                document.setText(newContent);
+                document.deleteString(lineStartOffset, lineEndOffset);
             };
             WriteCommandAction.runWriteCommandAction(feature.getProject(), r);
         }


### PR DESCRIPTION
Instead of manipulating the string content of the document to remove the feature, I directly used the deleteString method of the Document class. 

The lineStartOffset and lineEndOffset are calculated based on the line numbers of the feature's text offset, ensuring the deletion of the entire line where the feature is located, regardless of its length or content.