### PR TITLE
SettingsPageHanS- SettingsPage,CheckboxBuilder,SectionBuilder - Tim Anakin 

### DIFF
--- a/.feature-model
+++ b/.feature-model
@@ -1,5 +1,4 @@
 HAnS
-    SettingsPage
     FeatureModel
         Language
         File
@@ -42,4 +41,5 @@ HAnS
     FileTemplate
         NewFile
     Quickfix
+    SettingsPage
 

--- a/.feature-model
+++ b/.feature-model
@@ -1,4 +1,5 @@
 HAnS
+    SettingsPage
     FeatureModel
         Language
         File
@@ -41,3 +42,4 @@ HAnS
     FileTemplate
         NewFile
     Quickfix
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 - Added a View of the metrics to the project
+- Added the HanS Settings Page without given functionality
 
 ## [0.0.4] - 2024-03-06
 
@@ -75,6 +76,7 @@ First Release to marketplace
 - Live templates
 - Code annotation quickfix
 - Syntax highlighter settings
+
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 | Luca Kramer        | [![Luca github](https://img.shields.io/badge/GitHub-LucaKramer-181717.svg?style=flat&logo=github)](https://www.github.com/LucaKramer)         |
 
 
+
 | Project Contributors | [![isselab github](https://img.shields.io/badge/GitHub-isselab-181717.svg?style=flat&logo=github)](https://www.github.com/isselab)             |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Thorsten Berger      | [![Thorsten github](https://img.shields.io/badge/GitHub-thorstenberger-181717.svg?style=flat&logo=github)](https://www.github.com/thorstenberger) |

--- a/src/main/java/se/isselab/HAnS/settingsPage/.feature-to-file
+++ b/src/main/java/se/isselab/HAnS/settingsPage/.feature-to-file
@@ -1,0 +1,2 @@
+SettingsPageHanS.java,SectionBuilder.java,CheckboxBuilder.java
+SettingsPage

--- a/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
@@ -1,6 +1,6 @@
 /**
- Copyright 2023 Johan Martinson & Herman Jansson
-
+ Copyright 2024 Tim Sülz
+ 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
@@ -15,15 +15,17 @@
  **/
 package se.isselab.HAnS.settingsPage;
 
+import com.intellij.ui.*;
+
 import javax.swing.*;
 import java.awt.*;
 
 public class CheckboxBuilder {
 
-        private JPanel panel;
-        private JCheckBox checkBox;
+        private final JPanel panel;
+        private  final JCheckBox checkBox;
 
-        final int DISTANCE = 20;
+        final int DISTANCE = 5;
     /** Checkbox Builder builds a panel in the form of the base IntelliJ Layout with a checkbox and an optional  **/
     public CheckboxBuilder(String checkboxText, String descriptionText) {
         panel = new JPanel();
@@ -42,18 +44,18 @@ public class CheckboxBuilder {
         gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
         gbc.weighty = 1;
         gbc.weightx = 1;
-        gbc.insets = new Insets(5, DISTANCE+5, 5, 5); // Add some padding
+        gbc.insets = new Insets(5, DISTANCE+5, 5, DISTANCE); // Add some padding
         panel.add(checkBox, gbc); // Add checkbox with constraints
 
         GridBagConstraints gbclabel = new GridBagConstraints();
         gbclabel.gridx = 0;
         gbclabel.gridy = 1;
         gbclabel.anchor = GridBagConstraints.NORTHWEST;
-        gbclabel.insets = new Insets(25, DISTANCE+28, 5, 5);
+        gbclabel.insets = new Insets(25, DISTANCE+28, 5, DISTANCE);
 
 
         JLabel descriptionLabel = new JLabel(descriptionText);
-        descriptionLabel.setForeground(Color.GRAY);
+        descriptionLabel.setForeground(JBColor.GRAY);
 
 
         gbc.gridy++; // Move to the next row
@@ -78,7 +80,7 @@ public class CheckboxBuilder {
         gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
         gbc.weighty = 1;
         gbc.weightx = 1;
-        gbc.insets = new Insets(5, DISTANCE+5, 5, 5); // Add some padding
+        gbc.insets = new Insets(5, DISTANCE+8, 5, DISTANCE); // Add some padding
         panel.add(checkBox, gbc); // Add checkbox with constraints
 
 

--- a/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
@@ -1,0 +1,101 @@
+/**
+ Copyright 2023 Johan Martinson & Herman Jansson
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **/
+package se.isselab.HAnS.settingsPage;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class CheckboxBuilder {
+
+        private JPanel panel;
+        private JCheckBox checkBox;
+
+        final int DISTANCE = 20;
+    /** Checkbox Builder builds a panel in the form of the base IntelliJ Layout with a checkbox and an optional  **/
+    public CheckboxBuilder(String checkboxText, String descriptionText) {
+        panel = new JPanel();
+        panel.setLayout(new GridBagLayout()); // Use GridBagLayout for more control
+
+        panel.setMaximumSize(new Dimension(1000, 55));
+
+
+
+        checkBox = new JCheckBox(checkboxText);
+
+        // Create GridBagConstraints for the checkbox
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0; // Set the column position
+        gbc.gridy = 0; // Set the row position
+        gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
+        gbc.weighty = 1;
+        gbc.weightx = 1;
+        gbc.insets = new Insets(5, DISTANCE+5, 5, 5); // Add some padding
+        panel.add(checkBox, gbc); // Add checkbox with constraints
+
+        GridBagConstraints gbclabel = new GridBagConstraints();
+        gbclabel.gridx = 0;
+        gbclabel.gridy = 1;
+        gbclabel.anchor = GridBagConstraints.NORTHWEST;
+        gbclabel.insets = new Insets(25, DISTANCE+28, 5, 5);
+
+
+        JLabel descriptionLabel = new JLabel(descriptionText);
+        descriptionLabel.setForeground(Color.GRAY);
+
+
+        gbc.gridy++; // Move to the next row
+        panel.add(checkBox, gbc);
+        panel.add(descriptionLabel,gbclabel);// Add description label with constraints
+    }
+
+    public CheckboxBuilder(String checkboxText) {
+        panel = new JPanel();
+        panel.setLayout(new GridBagLayout()); // Use GridBagLayout for more control
+
+        panel.setMaximumSize(new Dimension(1000, 30));
+
+
+
+        checkBox = new JCheckBox(checkboxText);
+
+        // Create GridBagConstraints for the checkbox
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0; // Set the column position
+        gbc.gridy = 0; // Set the row position
+        gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
+        gbc.weighty = 1;
+        gbc.weightx = 1;
+        gbc.insets = new Insets(5, DISTANCE+5, 5, 5); // Add some padding
+        panel.add(checkBox, gbc); // Add checkbox with constraints
+
+
+
+
+
+        // Create GridBagConstraints for the description label
+        gbc.gridy++; // Move to the next row
+        panel.add(checkBox, gbc);
+
+    }
+
+        public JPanel getPanel() {
+            return panel;
+        }
+
+        public JCheckBox getCheckbox() {
+            return checkBox;
+        }
+}

--- a/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
@@ -80,7 +80,7 @@ public class CheckboxBuilder {
         gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
         gbc.weighty = 1;
         gbc.weightx = 1;
-        gbc.insets = new Insets(5, DISTANCE+8, 5, DISTANCE); // Add some padding
+        gbc.insets = new Insets(5, DISTANCE+5, 5, DISTANCE); // Add some padding
         panel.add(checkBox, gbc); // Add checkbox with constraints
 
 

--- a/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
@@ -16,6 +16,7 @@
 package se.isselab.HAnS.settingsPage;
 
 import com.intellij.ui.*;
+import com.intellij.util.ui.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -44,14 +45,14 @@ public class CheckboxBuilder {
         gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
         gbc.weighty = 1;
         gbc.weightx = 1;
-        gbc.insets = new Insets(5, DISTANCE+5, 5, DISTANCE); // Add some padding
+        gbc.insets = JBUI.insets(5, DISTANCE+5, 5, DISTANCE); // Add some padding
         panel.add(checkBox, gbc); // Add checkbox with constraints
 
         GridBagConstraints gbclabel = new GridBagConstraints();
         gbclabel.gridx = 0;
         gbclabel.gridy = 1;
         gbclabel.anchor = GridBagConstraints.NORTHWEST;
-        gbclabel.insets = new Insets(25, DISTANCE+28, 5, DISTANCE);
+        gbclabel.insets = JBUI.insets(25, DISTANCE+28, 5, DISTANCE);
 
 
         JLabel descriptionLabel = new JLabel(descriptionText);
@@ -80,7 +81,7 @@ public class CheckboxBuilder {
         gbc.anchor = GridBagConstraints.NORTHWEST;// Align to the left
         gbc.weighty = 1;
         gbc.weightx = 1;
-        gbc.insets = new Insets(5, DISTANCE+5, 5, DISTANCE); // Add some padding
+        gbc.insets = JBUI.insets(5, DISTANCE+5, 5, DISTANCE); // Add some padding
         panel.add(checkBox, gbc); // Add checkbox with constraints
 
 

--- a/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/CheckboxBuilder.java
@@ -26,13 +26,15 @@ public class CheckboxBuilder {
         private final JPanel panel;
         private  final JCheckBox checkBox;
 
-        final int DISTANCE = 5;
+         private final int DISTANCE = 5;
     /** Checkbox Builder builds a panel in the form of the base IntelliJ Layout with a checkbox and an optional  **/
     public CheckboxBuilder(String checkboxText, String descriptionText) {
         panel = new JPanel();
         panel.setLayout(new GridBagLayout()); // Use GridBagLayout for more control
 
         panel.setMaximumSize(new Dimension(1000, 55));
+        panel.setOpaque(true);
+
 
 
 

--- a/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
@@ -1,0 +1,66 @@
+/**
+ Copyright 2023 Johan Martinson & Herman Jansson
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **/
+package se.isselab.HAnS.settingsPage;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class SectionBuilder {
+
+    private JPanel settingsPanel;
+
+    private final int WIDTH = 10000;
+
+    /** Section Builder builds the Default Sections for IntelliJ in the Form of a normal panel **/
+    public SectionBuilder(String name) {
+        settingsPanel = new JPanel();
+        GridBagLayout layout = new GridBagLayout();
+        settingsPanel.setLayout(layout);
+        settingsPanel.setOpaque(true);
+
+        JLabel titleLabel = new JLabel(name);
+        titleLabel.setOpaque(true);
+
+        JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
+
+        settingsPanel.setMaximumSize(new Dimension(WIDTH, titleLabel.getPreferredSize().height + 5));
+
+        GridBagConstraints c1 = new GridBagConstraints();
+        c1.fill = GridBagConstraints.HORIZONTAL;
+        c1.weighty = 1;
+        c1.weightx = 0.0001;
+        c1.gridx = 0;
+        c1.gridy = 0;
+        c1.anchor = GridBagConstraints.NORTHWEST;
+        c1.insets = new Insets(0, 0, 0, 5);
+
+        GridBagConstraints c2 = new GridBagConstraints();
+        c2.fill = GridBagConstraints.HORIZONTAL;
+        c2.weighty = 1;
+        c2.weightx = 1;
+        c2.gridx = 1;
+        c2.gridy = 0;
+        c2.anchor = GridBagConstraints.NORTHWEST;
+        c2.insets = new Insets(7, 5, 0, 0);
+
+        settingsPanel.add(titleLabel, c1);
+        settingsPanel.add(separator, c2);
+    }
+
+    public JPanel getSettingsPanel() {
+        return settingsPanel;
+    }
+}

--- a/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
@@ -48,7 +48,7 @@ public class SectionBuilder {
         c1.gridx = 0;
         c1.gridy = 0;
         c1.anchor = GridBagConstraints.NORTHWEST;
-        c1.insets = new Insets(0, 0, 0, 5);
+        c1.insets = JBUI.insetsRight(5);
 
         GridBagConstraints c2 = new GridBagConstraints();
         c2.fill = GridBagConstraints.HORIZONTAL;

--- a/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
@@ -15,17 +15,20 @@
  **/
 package se.isselab.HAnS.settingsPage;
 
+import com.intellij.util.ui.*;
+
 import javax.swing.*;
 import java.awt.*;
 
 public class SectionBuilder {
 
-    private JPanel settingsPanel;
+    private final JPanel settingsPanel;
 
-    private final int WIDTH = 10000;
+
 
     /** Section Builder builds the Default Sections for IntelliJ in the Form of a normal panel **/
     public SectionBuilder(String name) {
+        int WIDTH = 10000;
         settingsPanel = new JPanel();
         GridBagLayout layout = new GridBagLayout();
         settingsPanel.setLayout(layout);
@@ -54,7 +57,7 @@ public class SectionBuilder {
         c2.gridx = 1;
         c2.gridy = 0;
         c2.anchor = GridBagConstraints.NORTHWEST;
-        c2.insets = new Insets(7, 5, 0, 0);
+        c2.insets = JBUI.insets(7, 5, 0, 0);
 
         settingsPanel.add(titleLabel, c1);
         settingsPanel.add(separator, c2);

--- a/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
@@ -1,5 +1,5 @@
 /**
- Copyright 2023 Johan Martinson & Herman Jansson
+ Copyright 2024 Tim Sülz
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SectionBuilder.java
@@ -22,24 +22,25 @@ import java.awt.*;
 
 public class SectionBuilder {
 
-    private final JPanel settingsPanel;
+    private final JPanel panel;
 
 
 
     /** Section Builder builds the Default Sections for IntelliJ in the Form of a normal panel **/
     public SectionBuilder(String name) {
-        int WIDTH = 10000;
-        settingsPanel = new JPanel();
+        int width = 10000;
+        panel = new JPanel();
         GridBagLayout layout = new GridBagLayout();
-        settingsPanel.setLayout(layout);
-        settingsPanel.setOpaque(true);
+        panel.setLayout(layout);
+        panel.setOpaque(true);
+
 
         JLabel titleLabel = new JLabel(name);
         titleLabel.setOpaque(true);
 
         JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
 
-        settingsPanel.setMaximumSize(new Dimension(WIDTH, titleLabel.getPreferredSize().height + 5));
+        panel.setMaximumSize(new Dimension(width, titleLabel.getPreferredSize().height + 5));
 
         GridBagConstraints c1 = new GridBagConstraints();
         c1.fill = GridBagConstraints.HORIZONTAL;
@@ -59,11 +60,10 @@ public class SectionBuilder {
         c2.anchor = GridBagConstraints.NORTHWEST;
         c2.insets = JBUI.insets(7, 5, 0, 0);
 
-        settingsPanel.add(titleLabel, c1);
-        settingsPanel.add(separator, c2);
+        panel.add(titleLabel, c1);
+        panel.add(separator, c2);
     }
-
-    public JPanel getSettingsPanel() {
-        return settingsPanel;
+    public JPanel getPanel() {
+        return panel;
     }
 }

--- a/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageBuilder.java
@@ -46,21 +46,18 @@ public class SettingsPageBuilder implements Configurable {
         JBTabbedPane tabbedPane = new JBTabbedPane();
 
         // General Settings Tab
-        JPanel generalSettingsPanel = new JPanel();
-        generalSettingsPanel.setLayout(new BoxLayout(generalSettingsPanel, BoxLayout.Y_AXIS));
+        JPanel generalTab = new JPanel();
+        generalTab.setLayout(new BoxLayout(generalTab, BoxLayout.Y_AXIS));
 
-        tabbedPane.addTab("General Settings", generalSettingsPanel);
+        tabbedPane.addTab("General", generalTab);
 
 
         // Section Hide Annotations
         SectionBuilder hideAnnotationsSection = new SectionBuilder("Hide Annotations"); // Builds the section Hide Annotations
-        generalSettingsPanel.add(hideAnnotationsSection.getPanel());// Builds the section Hide Annotations into the generalSettings Panel
-
-
+        generalTab.add(hideAnnotationsSection.getPanel());// Builds the section Hide Annotations into the generalSettings Panel
         CheckboxBuilder enableHideAnnotationsCheckbox = new CheckboxBuilder("Enable Hide Annotations", "This Enables the Hide Annotation functionality ");// Builds the Checkbox
-        generalSettingsPanel.add(enableHideAnnotationsCheckbox.getPanel()); // add the Checkbox in typical IntelliJ Style to the Panel
+        generalTab.add(enableHideAnnotationsCheckbox.getPanel()); // add the Checkbox in typical IntelliJ Style to the Panel
 
-        // Adding action listener to the checkbox
         enableHideAnnotationsCheckbox.getCheckbox().addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -70,15 +67,10 @@ public class SettingsPageBuilder implements Configurable {
 
         // Section Logging
         SectionBuilder loggingSection = new SectionBuilder("Logging");
-        generalSettingsPanel.add(loggingSection.getPanel());
-
-
+        generalTab.add(loggingSection.getPanel());
         CheckboxBuilder enableLoggingCheckbox = new CheckboxBuilder("Enable Logging");
-        generalSettingsPanel.add(enableLoggingCheckbox.getPanel());
+        generalTab.add(enableLoggingCheckbox.getPanel());
 
-
-
-        // Adding action listener to the checkbox
         enableLoggingCheckbox.getCheckbox().addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -87,16 +79,14 @@ public class SettingsPageBuilder implements Configurable {
             }
         });
 
-        generalSettingsPanel.add(Box.createRigidArea(new Dimension(0, 10)));
-
-
-
+        generalTab.add(Box.createRigidArea(new Dimension(0, 10)));
 
         // Clone Settings Tab
         JPanel cloneSettingsPanel = new JPanel();
         cloneSettingsPanel.setLayout(new BoxLayout(cloneSettingsPanel, BoxLayout.Y_AXIS));
+
         // Section Clone Settings
-        SectionBuilder cloneSection = new SectionBuilder("Clone Settings");
+        SectionBuilder cloneSection = new SectionBuilder("Asset Management");
         cloneSettingsPanel.add(cloneSection.getPanel());
 
         CheckboxBuilder enableCloningTraceCheckbox = new CheckboxBuilder("Enable Cloning Trace Tracking");
@@ -132,7 +122,7 @@ public class SettingsPageBuilder implements Configurable {
         });
 
         cloneSettingsPanel.add(Box.createRigidArea(new Dimension(0, 10)));
-        tabbedPane.addTab("Clone Settings", cloneSettingsPanel);
+        tabbedPane.addTab("Asset Management", cloneSettingsPanel);
 
         panel.add(tabbedPane);
 

--- a/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageBuilder.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageBuilder.java
@@ -25,7 +25,7 @@ import javax.swing.border.*;
 import java.awt.*;
 import java.awt.event.*;
 
-public class SettingsPageHanS implements Configurable {
+public class SettingsPageBuilder implements Configurable {
     @Override
     public @NlsContexts.ConfigurableName String getDisplayName() {
         return "HanS Plugin Settings";
@@ -75,6 +75,7 @@ public class SettingsPageHanS implements Configurable {
 
         CheckboxBuilder enableLoggingCheckbox = new CheckboxBuilder("Enable Logging");
         generalSettingsPanel.add(enableLoggingCheckbox.getPanel());
+
 
 
         // Adding action listener to the checkbox

--- a/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
@@ -52,7 +52,7 @@ public class SettingsPageHanS implements Configurable {
         tabbedPane.addTab("General Settings", generalSettingsPanel);
         // Section Hide Annotations
         SectionBuilder hideAnnotationsSection = new SectionBuilder("Hide Annotations"); // Builds the section Hide Annotations
-        generalSettingsPanel.add(hideAnnotationsSection.getSettingsPanel());// Builds the section Hide Annotations into the generalSettings Panel
+        generalSettingsPanel.add(hideAnnotationsSection.getPanel());// Builds the section Hide Annotations into the generalSettings Panel
 
 
         CheckboxBuilder enableHideAnnotationsCheckbox = new CheckboxBuilder("Enable Hide Annotations", "This Enables the Hide Annotation functionality ");// Builds the Checkbox
@@ -68,7 +68,7 @@ public class SettingsPageHanS implements Configurable {
 
         // Section Logging
         SectionBuilder loggingSection = new SectionBuilder("Logging");
-        generalSettingsPanel.add(loggingSection.getSettingsPanel());
+        generalSettingsPanel.add(loggingSection.getPanel());
 
 
         CheckboxBuilder enableLoggingCheckbox = new CheckboxBuilder("Enable Logging");
@@ -85,12 +85,15 @@ public class SettingsPageHanS implements Configurable {
 
         generalSettingsPanel.add(Box.createRigidArea(new Dimension(0, 10)));
 
+
+
+
         // Clone Settings Tab
         JPanel cloneSettingsPanel = new JPanel();
         cloneSettingsPanel.setLayout(new BoxLayout(cloneSettingsPanel, BoxLayout.Y_AXIS));
         // Section Clone Settings
         SectionBuilder cloneSection = new SectionBuilder("Clone Settings");
-        cloneSettingsPanel.add(cloneSection.getSettingsPanel());
+        cloneSettingsPanel.add(cloneSection.getPanel());
 
         CheckboxBuilder enableCloningTraceCheckbox = new CheckboxBuilder("Enable Cloning Trace Tracking");
         cloneSettingsPanel.add(enableCloningTraceCheckbox.getPanel());

--- a/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
@@ -50,6 +50,8 @@ public class SettingsPageHanS implements Configurable {
         generalSettingsPanel.setLayout(new BoxLayout(generalSettingsPanel, BoxLayout.Y_AXIS));
 
         tabbedPane.addTab("General Settings", generalSettingsPanel);
+
+
         // Section Hide Annotations
         SectionBuilder hideAnnotationsSection = new SectionBuilder("Hide Annotations"); // Builds the section Hide Annotations
         generalSettingsPanel.add(hideAnnotationsSection.getPanel());// Builds the section Hide Annotations into the generalSettings Panel
@@ -73,6 +75,7 @@ public class SettingsPageHanS implements Configurable {
 
         CheckboxBuilder enableLoggingCheckbox = new CheckboxBuilder("Enable Logging");
         generalSettingsPanel.add(enableLoggingCheckbox.getPanel());
+
 
         // Adding action listener to the checkbox
         enableLoggingCheckbox.getCheckbox().addActionListener(new ActionListener() {

--- a/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
@@ -1,5 +1,5 @@
 /**
- Copyright 2023 Johan Martinson & Herman Jansson
+ Copyright 2024 Tim Sülz
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
+++ b/src/main/java/se/isselab/HAnS/settingsPage/SettingsPageHanS.java
@@ -1,0 +1,150 @@
+/**
+ Copyright 2023 Johan Martinson & Herman Jansson
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **/
+package se.isselab.HAnS.settingsPage;
+
+import com.intellij.openapi.options.*;
+import com.intellij.openapi.util.*;
+import com.intellij.ui.components.*;
+import org.jetbrains.annotations.*;
+
+import javax.swing.*;
+import javax.swing.border.*;
+import java.awt.*;
+import java.awt.event.*;
+
+public class SettingsPageHanS implements Configurable {
+    @Override
+    public @NlsContexts.ConfigurableName String getDisplayName() {
+        return "HanS Plugin Settings";
+    }
+
+    @Override
+    public @Nullable JComponent createComponent() {
+
+        // Creating Base Panel
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        JLabel pluginDescriptionLabel = new JLabel("Settings for the HanS Plugin");
+        pluginDescriptionLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panel.add(pluginDescriptionLabel);
+
+        // Creating different Tabs
+        JBTabbedPane tabbedPane = new JBTabbedPane();
+
+        // General Settings Tab
+        JPanel generalSettingsPanel = new JPanel();
+        generalSettingsPanel.setLayout(new BoxLayout(generalSettingsPanel, BoxLayout.Y_AXIS));
+
+        tabbedPane.addTab("General Settings", generalSettingsPanel);
+        // Section Hide Annotations
+        SectionBuilder hideAnnotationsSection = new SectionBuilder("Hide Annotations"); // Builds the section Hide Annotations
+        generalSettingsPanel.add(hideAnnotationsSection.getSettingsPanel());// Builds the section Hide Annotations into the generalSettings Panel
+
+
+        CheckboxBuilder enableHideAnnotationsCheckbox = new CheckboxBuilder("Enable Hide Annotations", "This Enables the Hide Annotation functionality ");// Builds the Checkbox
+        generalSettingsPanel.add(enableHideAnnotationsCheckbox.getPanel()); // add the Checkbox in typical IntelliJ Style to the Panel
+
+        // Adding action listener to the checkbox
+        enableHideAnnotationsCheckbox.getCheckbox().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+             // TODO Add Hide Annotations functionality
+            }
+        });
+
+        // Section Logging
+        SectionBuilder loggingSection = new SectionBuilder("Logging");
+        generalSettingsPanel.add(loggingSection.getSettingsPanel());
+
+
+        CheckboxBuilder enableLoggingCheckbox = new CheckboxBuilder("Enable Logging");
+        generalSettingsPanel.add(enableLoggingCheckbox.getPanel());
+
+        // Adding action listener to the checkbox
+        enableLoggingCheckbox.getCheckbox().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //TODO Add logging functionality
+
+            }
+        });
+
+        generalSettingsPanel.add(Box.createRigidArea(new Dimension(0, 10)));
+
+        // Clone Settings Tab
+        JPanel cloneSettingsPanel = new JPanel();
+        cloneSettingsPanel.setLayout(new BoxLayout(cloneSettingsPanel, BoxLayout.Y_AXIS));
+        // Section Clone Settings
+        SectionBuilder cloneSection = new SectionBuilder("Clone Settings");
+        cloneSettingsPanel.add(cloneSection.getSettingsPanel());
+
+        CheckboxBuilder enableCloningTraceCheckbox = new CheckboxBuilder("Enable Cloning Trace Tracking");
+        cloneSettingsPanel.add(enableCloningTraceCheckbox.getPanel());
+
+        enableCloningTraceCheckbox.getCheckbox().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //TODO Clone Trace Tracking Functionality should be implemented here
+            }
+        });
+
+        CheckboxBuilder showCloneInfoCheckbox = new CheckboxBuilder("Show Clone Information");
+        cloneSettingsPanel.add(showCloneInfoCheckbox.getPanel());
+
+        showCloneInfoCheckbox.getCheckbox().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //TODO Show Clone Information should be added here
+
+            }
+        });
+
+        CheckboxBuilder sourcesSegmentChangesCheckbox = new CheckboxBuilder("Notify on Sources Segment Changes", "Here is the description text");
+        cloneSettingsPanel.add(sourcesSegmentChangesCheckbox.getPanel());
+
+        sourcesSegmentChangesCheckbox.getCheckbox().addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //TODO add the sources Segment Change functionality
+
+            }
+        });
+
+        cloneSettingsPanel.add(Box.createRigidArea(new Dimension(0, 10)));
+        tabbedPane.addTab("Clone Settings", cloneSettingsPanel);
+
+        panel.add(tabbedPane);
+
+        TitledBorder titledBorder = BorderFactory.createTitledBorder("HanS Feature Settings");
+        panel.setBorder(titledBorder);
+
+        return panel;
+    }
+
+
+    @Override
+    public boolean isModified() {
+
+        return true;
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+
+    }
+}
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,9 @@ limitations under the License.
         <lang.parserDefinition language="FeatureModel"
                                implementationClass="se.isselab.HAnS.featureModel.FeatureModelParserDefinition"/>
         <!-- &end[HAnS::FeatureModel] -->
+        <!-- &begin[SettingsPage] -->
+        <applicationConfigurable instance="se.isselab.HAnS.settingsPage.SettingsPageHanS"/>
+        <!-- &end[SettingsPage] -->
 
         <!-- &begin[HAnS::FileAnnotation] -->
         <fileType name="File Annotation File" implementationClass="se.isselab.HAnS.fileAnnotation.FileAnnotationFileType"
@@ -126,6 +129,8 @@ limitations under the License.
 
         <projectService serviceImplementation="se.isselab.HAnS.featureExtension.FeatureService" serviceInterface="se.isselab.HAnS.featureExtension.FeatureServiceInterface"/>
     </extensions>
+
+
 
     <extensionPoints>
         <!-- &begin[Service]-->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@ limitations under the License.
                                implementationClass="se.isselab.HAnS.featureModel.FeatureModelParserDefinition"/>
         <!-- &end[HAnS::FeatureModel] -->
         <!-- &begin[SettingsPage] -->
-        <applicationConfigurable instance="se.isselab.HAnS.settingsPage.SettingsPageHanS"/>
+        <applicationConfigurable instance="se.isselab.HAnS.settingsPage.SettingsPageBuilder"/>
         <!-- &end[SettingsPage] -->
 
         <!-- &begin[HAnS::FileAnnotation] -->


### PR DESCRIPTION
So as IntelliJ doesnt provide anything on how to achieve their default settings UI, i wanted to create an easier way to reproduce the look of the UI Settings by creating a section and a checkbox builder which allow to place sections and checkboxes looking exactly like those in the default settings. You can create Instances of the CheckboxBuilder with and without desciptions. I also added a few basic checkboxes and sections, but the checkboxes doesnt have any functionality. Finally i created a different tab for the cloning Settings for @Ahmad-sh7, so that he can simply integrate his checkbox functionality into the UI. Because of an error after forking the build doesnt seem to work so i changed a few things. Now it should work
