### PR TITLE
Show feature code for code annotations and file annotations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ platformVersion = 2023.3.7
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = com.intellij.java
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.9

--- a/src/main/java/se/isselab/HAnS/referencing/CustomPsiElement.java
+++ b/src/main/java/se/isselab/HAnS/referencing/CustomPsiElement.java
@@ -1,0 +1,296 @@
+package se.isselab.HAnS.referencing;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.Language;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import com.intellij.psi.impl.PsiElementBase;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class CustomPsiElement implements PsiElement { // Ersetzen Sie MyPsiElementBase durch Ihre tatsächliche Basis-Klasse
+    private final String customName;
+    private final PsiElement element;
+
+    public CustomPsiElement(PsiElement element, String customName) {
+        this.customName = customName;
+        this.element = element;
+    }
+
+    @Override
+    public @NotNull Project getProject() throws PsiInvalidElementAccessException {
+        return element.getProject();
+    }
+
+    @Override
+    public @NotNull Language getLanguage() {
+        return element.getLanguage();
+    }
+
+    @Override
+    public PsiManager getManager() {
+        return element.getManager();
+    }
+
+    @Override
+    public @NotNull PsiElement @NotNull [] getChildren() {
+        return element.getChildren();
+    }
+
+    @Override
+    public PsiElement getParent() {
+        return element.getParent();
+    }
+
+    @Override
+    public PsiElement getFirstChild() {
+        return element.getFirstChild();
+    }
+
+    @Override
+    public PsiElement getLastChild() {
+        return element.getLastChild();
+    }
+
+    @Override
+    public PsiElement getNextSibling() {
+        return element.getNextSibling();
+    }
+
+    @Override
+    public PsiElement getPrevSibling() {
+        return element.getPrevSibling();
+    }
+
+    @Override
+    public PsiFile getContainingFile() throws PsiInvalidElementAccessException {
+        return element.getContainingFile();
+    }
+
+    @Override
+    public TextRange getTextRange() {
+        return element.getTextRange();
+    }
+
+    @Override
+    public int getStartOffsetInParent() {
+        return element.getStartOffsetInParent();
+    }
+
+    @Override
+    public int getTextLength() {
+        return element.getTextLength();
+    }
+
+    @Override
+    public @Nullable PsiElement findElementAt(int i) {
+        return element.findElementAt(i);
+    }
+
+    @Override
+    public @Nullable PsiReference findReferenceAt(int i) {
+        return element.findReferenceAt(i);
+    }
+
+    @Override
+    public int getTextOffset() {
+        return element.getTextOffset();
+    }
+
+    @Override
+    public @NlsSafe String getText() {
+        return element.getText();
+    }
+
+    @Override
+    public char @NotNull [] textToCharArray() {
+        return element.textToCharArray();
+    }
+
+    @Override
+    public PsiElement getNavigationElement() {
+        return element.getNavigationElement();
+    }
+
+    @Override
+    public PsiElement getOriginalElement() {
+        return element.getOriginalElement();
+    }
+
+    @Override
+    public boolean textMatches(@NotNull @NonNls CharSequence charSequence) {
+        return element.textMatches(charSequence);
+    }
+
+    @Override
+    public boolean textMatches(@NotNull PsiElement psiElement) {
+        return element.textMatches(psiElement);
+    }
+
+    @Override
+    public boolean textContains(char c) {
+        return element.textContains(c);
+    }
+
+    @Override
+    public void accept(@NotNull PsiElementVisitor psiElementVisitor) {
+        element.accept(psiElementVisitor);
+    }
+
+    @Override
+    public void acceptChildren(@NotNull PsiElementVisitor psiElementVisitor) {
+        element.acceptChildren(psiElementVisitor);
+    }
+
+    @Override
+    public PsiElement copy() {
+        return  element.copy();
+    }
+
+    @Override
+    public PsiElement add(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+        return element.add(psiElement);
+    }
+
+    @Override
+    public PsiElement addBefore(@NotNull PsiElement psiElement, @Nullable PsiElement psiElement1) throws IncorrectOperationException {
+        return element.addBefore(psiElement, psiElement1);
+    }
+
+    @Override
+    public PsiElement addAfter(@NotNull PsiElement psiElement, @Nullable PsiElement psiElement1) throws IncorrectOperationException {
+        return null;
+    }
+
+    @Override
+    public void checkAdd(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public PsiElement addRange(PsiElement psiElement, PsiElement psiElement1) throws IncorrectOperationException {
+        return null;
+    }
+
+    @Override
+    public PsiElement addRangeBefore(@NotNull PsiElement psiElement, @NotNull PsiElement psiElement1, PsiElement psiElement2) throws IncorrectOperationException {
+        return null;
+    }
+
+    @Override
+    public PsiElement addRangeAfter(PsiElement psiElement, PsiElement psiElement1, PsiElement psiElement2) throws IncorrectOperationException {
+        return null;
+    }
+
+    @Override
+    public void delete() throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public void checkDelete() throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public void deleteChildRange(PsiElement psiElement, PsiElement psiElement1) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public PsiElement replace(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+        return null;
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isWritable() {
+        return false;
+    }
+
+    @Override
+    public @Nullable PsiReference getReference() {
+        return null;
+    }
+
+    @Override
+    public @NotNull PsiReference[] getReferences() {
+        return new PsiReference[]{
+                new CustomPsiReference(this, customName)
+        };
+    }
+
+    @Override
+    public <T> @Nullable T getCopyableUserData(@NotNull Key<T> key) {
+        return null;
+    }
+
+    @Override
+    public <T> void putCopyableUserData(@NotNull Key<T> key, @Nullable T t) {
+
+    }
+
+    @Override
+    public boolean processDeclarations(@NotNull PsiScopeProcessor psiScopeProcessor, @NotNull ResolveState resolveState, @Nullable PsiElement psiElement, @NotNull PsiElement psiElement1) {
+        return false;
+    }
+
+    @Override
+    public @Nullable PsiElement getContext() {
+        return null;
+    }
+
+    @Override
+    public boolean isPhysical() {
+        return false;
+    }
+
+    @Override
+    public @NotNull GlobalSearchScope getResolveScope() {
+        return null;
+    }
+
+    @Override
+    public @NotNull SearchScope getUseScope() {
+        return null;
+    }
+
+    @Override
+    public ASTNode getNode() {
+        return null;
+    }
+
+    @Override
+    public boolean isEquivalentTo(PsiElement psiElement) {
+        return false;
+    }
+
+    @Override
+    public Icon getIcon(int i) {
+        return null;
+    }
+
+    @Override
+    public <T> @Nullable T getUserData(@NotNull Key<T> key) {
+        return null;
+    }
+
+    @Override
+    public <T> void putUserData(@NotNull Key<T> key, @Nullable T t) {
+
+    }
+}

--- a/src/main/java/se/isselab/HAnS/referencing/CustomPsiElement.java
+++ b/src/main/java/se/isselab/HAnS/referencing/CustomPsiElement.java
@@ -169,128 +169,126 @@ public class CustomPsiElement implements PsiElement { // Ersetzen Sie MyPsiEleme
 
     @Override
     public PsiElement addAfter(@NotNull PsiElement psiElement, @Nullable PsiElement psiElement1) throws IncorrectOperationException {
-        return null;
+        return element.addAfter(psiElement, psiElement1);
     }
 
     @Override
     public void checkAdd(@NotNull PsiElement psiElement) throws IncorrectOperationException {
-
+        element.checkAdd(psiElement);
     }
 
     @Override
     public PsiElement addRange(PsiElement psiElement, PsiElement psiElement1) throws IncorrectOperationException {
-        return null;
+        return element.addRange(psiElement, psiElement1);
     }
 
     @Override
     public PsiElement addRangeBefore(@NotNull PsiElement psiElement, @NotNull PsiElement psiElement1, PsiElement psiElement2) throws IncorrectOperationException {
-        return null;
+        return element.addRangeBefore(psiElement, psiElement1, psiElement2);
     }
 
     @Override
     public PsiElement addRangeAfter(PsiElement psiElement, PsiElement psiElement1, PsiElement psiElement2) throws IncorrectOperationException {
-        return null;
+        return element.addRangeAfter(psiElement, psiElement1, psiElement2);
     }
 
     @Override
     public void delete() throws IncorrectOperationException {
-
+        element.delete();
     }
 
     @Override
     public void checkDelete() throws IncorrectOperationException {
-
+        element.checkDelete();
     }
 
     @Override
     public void deleteChildRange(PsiElement psiElement, PsiElement psiElement1) throws IncorrectOperationException {
-
+        element.deleteChildRange(psiElement, psiElement1);
     }
 
     @Override
     public PsiElement replace(@NotNull PsiElement psiElement) throws IncorrectOperationException {
-        return null;
+        return element.replace(psiElement);
     }
 
     @Override
     public boolean isValid() {
-        return false;
+        return element.isValid();
     }
 
     @Override
     public boolean isWritable() {
-        return false;
+        return element.isWritable();
     }
 
     @Override
     public @Nullable PsiReference getReference() {
-        return null;
+        return element.getReference();
     }
 
     @Override
     public @NotNull PsiReference[] getReferences() {
-        return new PsiReference[]{
-                new CustomPsiReference(this, customName)
-        };
+        return element.getReferences();
     }
 
     @Override
     public <T> @Nullable T getCopyableUserData(@NotNull Key<T> key) {
-        return null;
+        return element.getCopyableUserData(key);
     }
 
     @Override
     public <T> void putCopyableUserData(@NotNull Key<T> key, @Nullable T t) {
-
+        element.putCopyableUserData(key, t);
     }
 
     @Override
     public boolean processDeclarations(@NotNull PsiScopeProcessor psiScopeProcessor, @NotNull ResolveState resolveState, @Nullable PsiElement psiElement, @NotNull PsiElement psiElement1) {
-        return false;
+        return element.processDeclarations(psiScopeProcessor, resolveState, psiElement, psiElement1);
     }
 
     @Override
     public @Nullable PsiElement getContext() {
-        return null;
+        return element.getContext();
     }
 
     @Override
     public boolean isPhysical() {
-        return false;
+        return element.isPhysical();
     }
 
     @Override
     public @NotNull GlobalSearchScope getResolveScope() {
-        return null;
+        return element.getResolveScope();
     }
 
     @Override
     public @NotNull SearchScope getUseScope() {
-        return null;
+        return element.getUseScope();
     }
 
     @Override
     public ASTNode getNode() {
-        return null;
+        return element.getNode();
     }
 
     @Override
     public boolean isEquivalentTo(PsiElement psiElement) {
-        return false;
+        return element.isEquivalentTo(psiElement);
     }
 
     @Override
     public Icon getIcon(int i) {
-        return null;
+        return element.getIcon(i);
     }
 
     @Override
     public <T> @Nullable T getUserData(@NotNull Key<T> key) {
-        return null;
+        return element.getUserData(key);
     }
 
     @Override
     public <T> void putUserData(@NotNull Key<T> key, @Nullable T t) {
-
+        element.putUserData(key, t);
     }
 }

--- a/src/main/java/se/isselab/HAnS/referencing/CustomPsiElement.java
+++ b/src/main/java/se/isselab/HAnS/referencing/CustomPsiElement.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class CustomPsiElement implements PsiElement { // Ersetzen Sie MyPsiElementBase durch Ihre tatsächliche Basis-Klasse
+public class CustomPsiElement implements PsiElement {
     private final String customName;
     private final PsiElement element;
 
@@ -109,7 +109,7 @@ public class CustomPsiElement implements PsiElement { // Ersetzen Sie MyPsiEleme
 
     @Override
     public @NlsSafe String getText() {
-        return element.getText();
+        return customName;
     }
 
     @Override

--- a/src/main/java/se/isselab/HAnS/referencing/CustomTextPsiReference.java
+++ b/src/main/java/se/isselab/HAnS/referencing/CustomTextPsiReference.java
@@ -1,0 +1,24 @@
+package se.isselab.HAnS.referencing;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReferenceBase;
+import org.jetbrains.annotations.NotNull;
+
+public class CustomTextPsiReference extends PsiReferenceBase<PsiElement> {
+    private final String customName;
+
+    public CustomTextPsiReference(@NotNull PsiElement element, String customName) {
+        super(element);
+        this.customName = customName;
+    }
+
+    @Override
+    public @NotNull String getCanonicalText() {
+        return customName;
+    }
+
+    @Override
+    public PsiElement resolve() {
+        return getElement();
+    }
+}

--- a/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
+++ b/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
@@ -150,9 +150,8 @@ public class FeatureReference extends PsiPolyVariantReferenceBase<PsiElement> {
                     }
                     endLineNumber++;
                 }
-
-                // Add the FeatureModelFeature itself as a result
-                results.add(new PsiElementResolveResult(new CustomPsiElement(feature, null)));
+                String customName = feature.getName() + ": " + beginLineNumber + "-" + endLineNumber;
+                results.add(new PsiElementResolveResult(new CustomPsiElement(feature, customName)));
             }
         }
         return results.toArray(new ResolveResult[0]);

--- a/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
+++ b/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
@@ -156,9 +156,8 @@ public class FeatureReference extends PsiPolyVariantReferenceBase<PsiElement> {
                     endLineNumber++;
                 }
 
-
                 // Add the FeatureModelFeature itself as a result
-                results.add(new PsiElementResolveResult(feature));
+                results.add(new PsiElementResolveResult(new CustomPsiElement(feature, null)));
             }
         }
         return results.toArray(new ResolveResult[0]);

--- a/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
+++ b/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
@@ -17,18 +17,20 @@ package se.isselab.HAnS.referencing;
 
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementResolveResult;
-import com.intellij.psi.PsiReferenceBase;
-import com.intellij.psi.ResolveResult;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import se.isselab.HAnS.AnnotationIcons;
 import se.isselab.HAnS.codeAnnotation.psi.CodeAnnotationLpq;
 import se.isselab.HAnS.codeAnnotation.psi.impl.CodeAnnotationPsiImplUtil;
+import se.isselab.HAnS.featureLocation.FeatureLocationManager;
 import se.isselab.HAnS.featureModel.FeatureModelUtil;
 import se.isselab.HAnS.featureModel.psi.FeatureModelFeature;
 import se.isselab.HAnS.fileAnnotation.psi.FileAnnotationLpq;
@@ -38,12 +40,14 @@ import se.isselab.HAnS.folderAnnotation.psi.impl.FolderAnnotationPsiImplUtil;
 
 import java.util.*;
 
-public class FeatureReference extends PsiReferenceBase<PsiElement> {
+public class FeatureReference extends PsiPolyVariantReferenceBase<PsiElement> {
 
     private final String lpq;
+    private PsiElement element;
 
     public FeatureReference(@NotNull PsiElement element, TextRange textRange) {
         super(element, textRange);
+        this.element = element;
         lpq = element.getText().substring(textRange.getStartOffset(), textRange.getEndOffset());
     }
 
@@ -71,17 +75,6 @@ public class FeatureReference extends PsiReferenceBase<PsiElement> {
         return myElement;
     }
 
-    @Nullable
-    @Override
-    public PsiElement resolve() {
-        Project project = myElement.getProject();
-        final List<FeatureModelFeature> features = FeatureModelUtil.findLPQ(project, lpq);
-        List<ResolveResult> results = new ArrayList<>();
-        for (FeatureModelFeature feature : features) {
-            results.add(new PsiElementResolveResult(feature));
-        }
-        return results.size() == 1 ? results.get(0).getElement() : null;
-    }
 
     @Override
     public Object @NotNull [] getVariants() {
@@ -99,4 +92,90 @@ public class FeatureReference extends PsiReferenceBase<PsiElement> {
         return variants.toArray();
     }
 
+    private boolean isEndTag(PsiElement psiElement) {
+        if (psiElement.getText().startsWith("&end")) return true;
+        if (psiElement.getParent() != null) {
+            return isEndTag(psiElement.getParent());
+        }
+        return false;
+    }
+
+    @Override
+    public ResolveResult @NotNull [] multiResolve(boolean b) {
+        Project project = element.getProject();
+
+        List<ResolveResult> results = new ArrayList<>();
+
+        if(element instanceof FileAnnotationLpq) {
+            if(element.getParent() != null) {
+                String[] lines = element.getParent().getContainingFile().getText().split("\n");
+                String fileName = lines[0];
+
+                VirtualFile currentFile = element.getParent().getContainingFile().getVirtualFile();
+                VirtualFile parentFolder = currentFile != null ? currentFile.getParent() : null;
+
+                VirtualFile targetFile = null;
+
+                if (parentFolder != null) {
+                    for (VirtualFile file : parentFolder.getChildren()) {
+                        if (!file.isDirectory() && file.getName().equals(fileName)) {
+                            targetFile = file;
+                            break;
+                        }
+                    }
+                }
+
+                if(targetFile == null) return new ResolveResult[0];
+
+                PsiFile fileAsPsi = PsiManager.getInstance(project).findFile(targetFile);
+
+                if(fileAsPsi == null) return new ResolveResult[0];
+
+                results.add(new PsiElementResolveResult(fileAsPsi));
+            }
+        } else if(element instanceof CodeAnnotationLpq) {
+            if (isEndTag(element)) return ResolveResult.EMPTY_ARRAY;
+            final List<FeatureModelFeature> features = FeatureModelUtil.findLPQ(project, lpq);
+
+            for (FeatureModelFeature feature : features) {
+
+                PsiElement commentElement = ReadAction.compute(() -> PsiTreeUtil.getContextOfType(element, PsiComment.class));
+
+                if(commentElement == null) continue;
+
+                PsiFile file = commentElement.getContainingFile();
+                String[] lines = file.getText().split("\n");
+
+                int beginLineNumber = getLine(project, commentElement);
+                int endLineNumber = 1;
+
+                for(String line : lines) {
+                    if(endLineNumber > beginLineNumber && line.contains("&end[" + feature.getName() + "]")){
+                        break;
+                    }
+                    endLineNumber++;
+                }
+
+
+                // Add the FeatureModelFeature itself as a result
+                results.add(new PsiElementResolveResult(feature));
+            }
+        }
+        return results.toArray(new ResolveResult[0]);
+    }
+
+    private int getLine(Project project, PsiElement elem) {
+
+        PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(project);
+        PsiFile openedFile = ReadAction.compute(elem::getContainingFile);
+
+        //iterate over each psiElement and check for PsiComment-Feature-Annotations
+        if (openedFile == null)
+            return -1;
+        Document document = psiDocumentManager.getDocument(openedFile);
+        if (document == null)
+            return -1;
+
+        return document.getLineNumber(elem.getTextRange().getStartOffset());
+    }
 }

--- a/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
+++ b/src/main/java/se/isselab/HAnS/referencing/FeatureReference.java
@@ -108,26 +108,21 @@ public class FeatureReference extends PsiPolyVariantReferenceBase<PsiElement> {
         List<ResolveResult> results = new ArrayList<>();
 
         if(element instanceof FileAnnotationLpq) {
-            ApplicationManager.getApplication().runReadAction(new Runnable() {
-                @Override
-                public void run() {
-                    if (element.getParent() != null) {
-                        PsiFile cFile = ReadAction.compute(() -> element.getParent().getContainingFile());
-                        String[] lines = cFile.getText().split("\n");
+            ApplicationManager.getApplication().runReadAction(() -> {
+                if (element.getParent() != null) {
+                    PsiFile cFile = ReadAction.compute(() -> element.getParent().getContainingFile());
+                    String[] lines = cFile.getText().split("\n");
 
-                        ArrayList<String> fileNames = getAllFileNamesForFeature(lines, ((FileAnnotationLpq) element).getName());
+                    ArrayList<String> fileNames = getAllFileNamesForFeature(lines, ((FileAnnotationLpq) element).getName());
 
-                        VirtualFile currentFile = cFile.getVirtualFile();
-                        VirtualFile parentFolder = currentFile != null ? currentFile.getParent() : null;
+                    VirtualFile currentFile = cFile.getVirtualFile();
+                    VirtualFile parentFolder = currentFile != null ? currentFile.getParent() : null;
 
-                        for (String fileName : fileNames) {
-                            for (VirtualFile file : parentFolder.getChildren()) {
-                                if (!file.isDirectory() && file.getName().equals(fileName)) {
-                                    System.out.print("asdasd");
-                                    PsiFile fileAsPsi = ReadAction.compute(() -> PsiManager.getInstance(project).findFile(file));
-
-                                    results.add(new PsiElementResolveResult(fileAsPsi));
-                                }
+                    for (String fileName : fileNames) {
+                        for (VirtualFile file : parentFolder.getChildren()) {
+                            if (!file.isDirectory() && file.getName().equals(fileName)) {
+                                PsiFile fileAsPsi = ReadAction.compute(() -> PsiManager.getInstance(project).findFile(file));
+                                results.add(new PsiElementResolveResult(fileAsPsi));
                             }
                         }
                     }
@@ -141,7 +136,7 @@ public class FeatureReference extends PsiPolyVariantReferenceBase<PsiElement> {
 
                 PsiElement commentElement = ReadAction.compute(() -> PsiTreeUtil.getContextOfType(element, PsiComment.class));
 
-                if(commentElement == null) continue;
+                if (commentElement == null) continue;
 
                 PsiFile file = commentElement.getContainingFile();
                 String[] lines = file.getText().split("\n");
@@ -149,8 +144,8 @@ public class FeatureReference extends PsiPolyVariantReferenceBase<PsiElement> {
                 int beginLineNumber = getLine(project, commentElement);
                 int endLineNumber = 1;
 
-                for(String line : lines) {
-                    if(endLineNumber > beginLineNumber && line.contains("&end[" + feature.getName() + "]")){
+                for (String line : lines) {
+                    if (endLineNumber > beginLineNumber && line.contains("&end[" + feature.getName() + "]")) {
                         break;
                     }
                     endLineNumber++;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@ limitations under the License.
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- &begin[HAnS::FeatureModel] -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We modified the multiResolve method in FeatureReference.java to modify the find Usages functionality on a feature. This works differently on different type of feature references:
FolderAnnotation: Do nothing
CodeAnnotations: We ignore end tags to avoid redundant results. Additionally we retrieve the line numbers and create a custom PsiElement with the new name ("FeatureName: beinLineNumber-endLineNumber"), but the new name is not shown in the find usages tab.
FileAnnotations: For file annotations we look through the .feature-to-file and detect all files that the current feature is connected with. We then create ResolveResults out of those files and return them. The problem is that those files as ResolveResults are not shown, when we do find usages in general, but only when we do it in the .feature-to-file file. Interestingly when we debugged our solution, when calling find usages from somewhere else, the code searching for the files is still executes and finds the correct files and adds them to the result, but these are not shown in the find Usages result tab. (When and where correct results can be seen, is shown in the video.

Originally we wanted to use the FeatureLocationManager to find all FeatureLocations for the current feature, but the reference search inside it, calls our multiResolve method subsequently, causing an infinite recursion. We tried putting it to a background task and also asked in the forum (https://platform.jetbrains.com/t/long-running-reference-search-in-psireference-multiresolve-method/624), but nothing worked. Thats why we stuck with our original solution. Parts of the solution with the FeatureLocationManager can still be found in the main branch of our fork.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/isselab/HAnS/issues/44

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. We want to get rid of redundant begin and end tags in the find usages result for code annotations.
2.  For file annotations we want to show the files connected to the feature in the find usages result view.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Tests are created and passing
- [x] Manual testing
We tried testing the find Usages as can be seen in the video, but it has the aforementioned limitations

## Demo



https://github.com/user-attachments/assets/36a09433-e3b1-419c-b7bb-25fe633d0a31




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Pipeline changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Further issues
There are still the two problems with the results not showing correctly mentioned in the description.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the [CONTRIBUTORS] file.
- [ ] I have updated the [CHANGELOG].

[CONTRIBUTORS]: https://github.com/isselab/HAnS/blob/main/CONTRIBUTORS.md
[CHANGELOG]: https://github.com/isselab/HAnS/blob/main/CHANGELOG.md
