### PR TITLE
Fix runner disk-space flake: enable tool-cache cleanup for inspectCode and verify jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Maximize Build Space
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: false
+          tool-cache: true
           large-packages: false
 
       # Check out the current repository
@@ -181,7 +181,7 @@ jobs:
       - name: Maximize Build Space
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: false
+          tool-cache: true
           large-packages: false
 
       # Check out the current repository


### PR DESCRIPTION
## Problem

The `inspectCode` and `verify` jobs have been intermittently failing with:

```
IOException: No space left on device : /home/runner/actions-runner/cached/_diag/Worker_*.log
```

This caused 5 open dependabot PRs (#187, #188, #190, #191, #194) to show a red `Verify plugin` check, blocking the merge queue. The failure is unrelated to any code changes in those PRs.

## Root cause

Both jobs already use `jlumbroso/free-disk-space` to free space before downloading large artifacts (Qodana + IntelliJ IDE binaries for plugin-verifier). However `tool-cache: false` was set, which leaves ~10 GB of pre-installed tooling on the runner untouched.

## Fix

Set `tool-cache: true` on both `inspectCode` and `verify` jobs. The tool cache is not used by either job, so removing it is safe and frees the space needed to avoid the `IOException`.