### PR TITLE
fix: flatten wiki sync, fix nav links

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -23,17 +23,33 @@ jobs:
           path: wiki-repo
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync wiki content
+      - name: Flatten and sync wiki content
         run: |
-          rsync -av --delete \
-            --exclude='.git/' \
-            --filter='- entities/' \
-            --filter='- meta/' \
-            --filter='- sources/' \
-            --filter='- log.md' \
-            --filter='- hot.md' \
-            --filter='- index.md' \
-            .wiki/wiki/ wiki-repo/
+          # Remove all existing content (preserve .git)
+          find wiki-repo -mindepth 1 -maxdepth 1 -not -name '.git' -exec rm -rf {} +
+
+          # Flatten: copy public .md files to wiki-repo root
+          # _index.md files are renamed to their parent directory name
+          # Exclude vault-only directories and files
+          find .wiki/wiki \
+            -not -path '*/.git/*' \
+            -not -path '*/entities/*' \
+            -not -path '*/meta/*' \
+            -not -path '*/sources/*' \
+            -name "*.md" \
+            ! -name "log.md" \
+            ! -name "hot.md" \
+            ! -name "index.md" \
+          | while IFS= read -r f; do
+            filename=$(basename "$f")
+            if [ "$filename" = "_index.md" ]; then
+              parent=$(basename "$(dirname "$f")")
+              dest="${parent}.md"
+            else
+              dest="$filename"
+            fi
+            cp "$f" "wiki-repo/$dest"
+          done
 
       - name: Commit and push
         working-directory: wiki-repo

--- a/.wiki/wiki/Home.md
+++ b/.wiki/wiki/Home.md
@@ -10,40 +10,40 @@
 
 | Module | Purpose |
 |--------|---------|
-| [Code Annotation](modules/Code-Annotation-Module) | `&begin`/`&end`/`&line` injection, PSI types |
-| [Feature Model](modules/HAnS-Feature-Model) | 52-feature hierarchy, `.feature-model` language |
-| [Feature Location](modules/Feature-Location-Module) | Location tracking, caching, file mapping |
-| [Metrics](modules/Metrics-Module) | Scattering, Tangling, Nesting Depth calculators |
-| [Plugin Extensions](modules/Plugin-Extensions-Module) | MetricsService, HighlighterService, background APIs |
-| [Build Configuration](modules/Build-Configuration) | Gradle setup, versions, plugins |
+| [Code Annotation](Code-Annotation-Module) | `&begin`/`&end`/`&line` injection, PSI types |
+| [Feature Model](HAnS-Feature-Model) | 52-feature hierarchy, `.feature-model` language |
+| [Feature Location](Feature-Location-Module) | Location tracking, caching, file mapping |
+| [Metrics](Metrics-Module) | Scattering, Tangling, Nesting Depth calculators |
+| [Plugin Extensions](Plugin-Extensions-Module) | MetricsService, HighlighterService, background APIs |
+| [Build Configuration](Build-Configuration) | Gradle setup, versions, plugins |
 
 ## Components
 
 | Component | Purpose |
 |-----------|---------|
-| [Annotation Syntax](components/Annotation-Syntax) | `&begin`/`&end`/`&line`, mapping files |
-| [Feature Model Language](components/Feature-Model-Language) | 4 languages, parser classes |
-| [Feature Model View](components/Feature-Model-View) | Tool window, left anchor |
-| [Feature Metrics View](components/Feature-Metrics-View) | Tool window, bottom anchor, 7 metrics |
-| [Traffic Light Indicator](components/Traffic-Light-Indicator) | InspectionWidget, 3 states |
-| [Extension Points](components/Extension-Points) | 5 EPs: metricsService, highlighterService, callbacks |
-| [Syntax Highlighting](components/Syntax-Highlighting) | 4 languages, Darcula + Default |
-| [Live Templates](components/Live-Templates) | `&begin`/`&end`/`&line` abbreviations |
+| [Annotation Syntax](Annotation-Syntax) | `&begin`/`&end`/`&line`, mapping files |
+| [Feature Model Language](Feature-Model-Language) | 4 languages, parser classes |
+| [Feature Model View](Feature-Model-View) | Tool window, left anchor |
+| [Feature Metrics View](Feature-Metrics-View) | Tool window, bottom anchor, 7 metrics |
+| [Traffic Light Indicator](Traffic-Light-Indicator) | InspectionWidget, 3 states |
+| [Extension Points](Extension-Points) | 5 EPs: metricsService, highlighterService, callbacks |
+| [Syntax Highlighting](Syntax-Highlighting) | 4 languages, Darcula + Default |
+| [Live Templates](Live-Templates) | `&begin`/`&end`/`&line` abbreviations |
 
 ## Decisions
 
 | ADR | Decision |
 |-----|---------|
-| [ADR-001](decisions/ADR-001-Extension-Points-for-Metrics) | Extension Points for Metrics |
-| [ADR-002](decisions/ADR-002-Dual-File-Extensions) | Dual File Extensions |
-| [ADR-003](decisions/ADR-003-Traffic-Light-Feature) | Traffic Light Feature |
-| [ADR-004](decisions/ADR-004-Optional-LPQ-Paths) | Optional LPQ Paths |
-| [ADR-005](decisions/ADR-005-Feature-Location-Caching) | Feature Location Caching |
+| [ADR-001](ADR-001-Extension-Points-for-Metrics) | Extension Points for Metrics |
+| [ADR-002](ADR-002-Dual-File-Extensions) | Dual File Extensions |
+| [ADR-003](ADR-003-Traffic-Light-Feature) | Traffic Light Feature |
+| [ADR-004](ADR-004-Optional-LPQ-Paths) | Optional LPQ Paths |
+| [ADR-005](ADR-005-Feature-Location-Caching) | Feature Location Caching |
 
 ## Dependencies
 
-[IntelliJ Platform](dependencies/IntelliJ-Platform) · [Kotlin](dependencies/Kotlin) · [Gradle Plugins](dependencies/Gradle-Plugins) · [Test Dependencies](dependencies/Test-Dependencies)
+[IntelliJ Platform](IntelliJ-Platform) · [Kotlin](Kotlin) · [Gradle Plugins](Gradle-Plugins) · [Test Dependencies](Test-Dependencies)
 
 ## Flows
 
-[Annotation Processing Flow](flows/Annotation-Processing-Flow)
+[Annotation Processing Flow](Annotation-Processing-Flow)

--- a/.wiki/wiki/_Sidebar.md
+++ b/.wiki/wiki/_Sidebar.md
@@ -3,38 +3,38 @@
 ---
 
 **Modules**
-- [Code Annotation](modules/Code-Annotation-Module)
-- [Feature Model](modules/HAnS-Feature-Model)
-- [Feature Location](modules/Feature-Location-Module)
-- [Metrics](modules/Metrics-Module)
-- [Plugin Extensions](modules/Plugin-Extensions-Module)
-- [Build Configuration](modules/Build-Configuration)
+- [Code Annotation](Code-Annotation-Module)
+- [Feature Model](HAnS-Feature-Model)
+- [Feature Location](Feature-Location-Module)
+- [Metrics](Metrics-Module)
+- [Plugin Extensions](Plugin-Extensions-Module)
+- [Build Configuration](Build-Configuration)
 
 **Components**
-- [Annotation Syntax](components/Annotation-Syntax)
-- [Feature Model Language](components/Feature-Model-Language)
-- [Feature Model View](components/Feature-Model-View)
-- [Feature Metrics View](components/Feature-Metrics-View)
-- [Traffic Light](components/Traffic-Light-Indicator)
-- [Extension Points](components/Extension-Points)
-- [Syntax Highlighting](components/Syntax-Highlighting)
-- [Live Templates](components/Live-Templates)
+- [Annotation Syntax](Annotation-Syntax)
+- [Feature Model Language](Feature-Model-Language)
+- [Feature Model View](Feature-Model-View)
+- [Feature Metrics View](Feature-Metrics-View)
+- [Traffic Light](Traffic-Light-Indicator)
+- [Extension Points](Extension-Points)
+- [Syntax Highlighting](Syntax-Highlighting)
+- [Live Templates](Live-Templates)
 
 **Decisions**
-- [ADR-001](decisions/ADR-001-Extension-Points-for-Metrics)
-- [ADR-002](decisions/ADR-002-Dual-File-Extensions)
-- [ADR-003](decisions/ADR-003-Traffic-Light-Feature)
-- [ADR-004](decisions/ADR-004-Optional-LPQ-Paths)
-- [ADR-005](decisions/ADR-005-Feature-Location-Caching)
+- [ADR-001](ADR-001-Extension-Points-for-Metrics)
+- [ADR-002](ADR-002-Dual-File-Extensions)
+- [ADR-003](ADR-003-Traffic-Light-Feature)
+- [ADR-004](ADR-004-Optional-LPQ-Paths)
+- [ADR-005](ADR-005-Feature-Location-Caching)
 
 **Dependencies**
-- [IntelliJ Platform](dependencies/IntelliJ-Platform)
-- [Kotlin](dependencies/Kotlin)
-- [Gradle Plugins](dependencies/Gradle-Plugins)
-- [Test Dependencies](dependencies/Test-Dependencies)
+- [IntelliJ Platform](IntelliJ-Platform)
+- [Kotlin](Kotlin)
+- [Gradle Plugins](Gradle-Plugins)
+- [Test Dependencies](Test-Dependencies)
 
 **Flows**
-- [Annotation Processing](flows/Annotation-Processing-Flow)
+- [Annotation Processing](Annotation-Processing-Flow)
 
 ---
 


### PR DESCRIPTION
Fixes broken links in GitHub wiki navigation (#199).

## Problem
GitHub wiki doesn't resolve relative subdirectory links correctly. `modules/Code-Annotation-Module` was routing to `wiki/isselab/HAnS/modules` (404).

## Fix
- **Workflow**: flatten all pages to wiki repo root on sync (`_index.md` → `{parent}.md`); exclude `entities/`, `meta/`, `sources/`, `log.md`, `hot.md`, `index.md`
- **Home.md + _Sidebar.md**: flat links (`Code-Annotation-Module` not `modules/Code-Annotation-Module`)

Sections visible via `_Sidebar.md` groupings. Vault directory structure unchanged.